### PR TITLE
Removing vulnerability

### DIFF
--- a/interface/templatetags/extra_tags.py
+++ b/interface/templatetags/extra_tags.py
@@ -1,4 +1,4 @@
-import markdown
+import markdown as markdown_lib
 from django import template
 from django.utils.safestring import mark_safe
 
@@ -24,7 +24,7 @@ def humanize_td(delta):
 
 @register.filter
 def markdown(text):
-    rendered = markdown.markdown(text)
+    rendered = markdown_lib.markdown(text)
 
     # Remove <code> blocks nested in <pre>
     rendered = rendered.replace('<pre><span></span><code>', '<pre>').replace('<pre><code>', '<pre>')

--- a/interface/templatetags/extra_tags.py
+++ b/interface/templatetags/extra_tags.py
@@ -1,4 +1,4 @@
-import markdown2
+import markdown
 from django import template
 from django.utils.safestring import mark_safe
 
@@ -24,8 +24,7 @@ def humanize_td(delta):
 
 @register.filter
 def markdown(text):
-    extras = ['header-ids', 'fenced-code-blocks', 'tables', 'code-friendly', 'cuddled-lists']
-    rendered = markdown2.markdown(text, extras=extras)
+    rendered = markdown.markdown(text)
 
     # Remove <code> blocks nested in <pre>
     rendered = rendered.replace('<pre><span></span><code>', '<pre>').replace('<pre><code>', '<pre>')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dj-database-url==0.4.1
 Django==1.10
 requests==2.12.4
-psycopg2==2.6.2
+psycopg2==2.7.3
 python-social-auth==0.2.21
 gunicorn==19.6.0
 whitenoise==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ whitenoise==3.2.1
 pygithub==1.26.0
 django-rq==0.9.5
 raven==6.0.0
-markdown2==2.3.3
+markdown2==2.4
 pathlib==1.0.1
 python-dateutil==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ whitenoise==3.2.1
 pygithub==1.26.0
 django-rq==0.9.5
 raven==6.0.0
-markdown2==2.4.1
+markdown==2.6.11
 pathlib==1.0.1
 python-dateutil==2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,6 @@ whitenoise==3.2.1
 pygithub==1.26.0
 django-rq==0.9.5
 raven==6.0.0
-markdown2==2.4
+markdown2==2.4.1
 pathlib==1.0.1
 python-dateutil==2.6.0


### PR DESCRIPTION
`markdown2` current version has a XSS vulnerability that hasn't been fixed yet. It was replaced along with a version bump for `psycopg2`.