### PR TITLE
Fmcdavid/upgrade python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dj-database-url==0.4.1
 Django==1.10
 requests==2.20.0
-psycopg2==2.7.3
+psycopg2==2.7.7
 python-social-auth==0.2.21
 gunicorn==19.6.0
 whitenoise==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ psycopg2==2.7.7
 python-social-auth==0.2.21
 gunicorn==19.6.0
 whitenoise==3.2.1
-pygithub==1.26.0
+pygithub==1.43.5
 django-rq==0.9.5
 raven==6.0.0
 markdown==2.6.11

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.7


### PR DESCRIPTION
upgrades python, psycopg2 and pygithub to allow an upgrade of the heroku stack to heroku-18